### PR TITLE
Replace gRPC with stolostron/grpc-go v1.72.1-patch for HTTPS proxy support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,4 +78,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace sigs.k8s.io/apiserver-network-proxy/konnectivity-client => ./konnectivity-client
+replace (
+	google.golang.org/grpc => github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => ./konnectivity-client
+)

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,6 @@ require (
 )
 
 replace (
-	google.golang.org/grpc => github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2
+	google.golang.org/grpc => github.com/stolostron/grpc-go v0.0.0-20260313103756-441825381483
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client => ./konnectivity-client
 )

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2 h1:rMg2uwmG31Wv+ticl+VuAiUWtw5b9Ys18uVQsRfXkOQ=
-github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
+github.com/stolostron/grpc-go v0.0.0-20260313103756-441825381483 h1:4JM22Z0Bxt/1pvooHgwlnuUyy300pfrZ2DKQvAtRNMs=
+github.com/stolostron/grpc-go v0.0.0-20260313103756-441825381483/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2 h1:rMg2uwmG31Wv+ticl+VuAiUWtw5b9Ys18uVQsRfXkOQ=
+github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -189,8 +191,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb h1:TLPQVbx1GJ8VKZxz52VAxl1EBgKXXbTiU9Fc5fZeLn4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
-google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=
-google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/google.golang.org/grpc/HTTPS_PROXY_PATCH_ANALYSIS.md
+++ b/vendor/google.golang.org/grpc/HTTPS_PROXY_PATCH_ANALYSIS.md
@@ -1,0 +1,221 @@
+# HTTPS Forward Proxy Support for grpc-go v1.72.1
+
+## Background
+
+gRPC-go does **not** support HTTPS forward proxies — that is, proxy servers
+where the initial connection to the proxy itself must be TLS-encrypted
+(`HTTPS_PROXY=https://proxy:443`). The upstream project explicitly documents
+this limitation:
+
+> Using CONNECT proxies via https is not supported. gRPC performs a plaintext
+> CONNECT handshake to establish a tunnel and does not support the additional
+> encryption required to secure the initial connection to the proxy itself.
+
+This is tracked upstream as [grpc/grpc#35372](https://github.com/grpc/grpc/issues/35372)
+(P2, `help wanted`), with no fix planned in the near term because it requires a
+cross-language design.
+
+### Why this matters for cluster-proxy / ANP
+
+Red Hat Advanced Cluster Management (RHACM) uses
+[apiserver-network-proxy (ANP)](https://github.com/kubernetes-sigs/apiserver-network-proxy)
+to tunnel traffic between hub and managed clusters. ANP relies on gRPC for its
+agent-to-server connection. In enterprise environments, managed clusters often
+sit behind an HTTPS forward proxy (e.g., F5, Squid with TLS) that requires
+TLS connections from clients. Because gRPC-go only supports HTTP CONNECT over
+plaintext TCP, the ANP agent cannot establish a tunnel through such proxies.
+
+The RHACM documentation already acknowledges this limitation:
+- `cluster_proxy_addon_config.adoc`: The `proxyConfig` sets environment
+  variables (`HTTPS_PROXY`), but gRPC-go ignores the `https` scheme.
+- `import_custom_bundle.adoc`: "If you bridge the SSL connections, the
+  cluster proxy add-on does not work."
+
+### Prior art
+
+A similar patch was applied to grpc-go v1.51.0 in
+[stolostron/grpc-go PR #5](https://github.com/stolostron/grpc-go/pull/5)
+(commit `72dd3e65`). That patch modified the `proxyDial` function in
+`internal/transport/proxy.go` to check `proxyURL.Scheme` and use `tls.Dial`
+for HTTPS proxies. However, grpc-go v1.72.1 has undergone significant
+architectural changes to proxy handling, and the v1.51.0 patch cannot be
+applied directly.
+
+---
+
+## Architecture: Proxy Handling in grpc-go v1.72.1
+
+The proxy handling code has been restructured into three layers since v1.51.0:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Layer 1: Proxy URL Detection & Resolution                        │
+│  File: internal/resolver/delegatingresolver/delegatingresolver.go │
+│                                                                     │
+│  - proxyURLForTarget() calls http.ProxyFromEnvironment()            │
+│  - Detects proxy from HTTPS_PROXY / HTTP_PROXY env vars             │
+│  - Returns *url.URL with Scheme ("http" or "https")                 │
+│  - delegatingResolver stores it as r.proxyURL                       │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               │  proxyattributes.Options (data container)
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  Layer 2: Proxy Attributes                                         │
+│  File: internal/proxyattributes/proxyattributes.go                 │
+│                                                                     │
+│  Options struct:                                                    │
+│    - User        *url.Userinfo   (proxy auth credentials)           │
+│    - ConnectAddr string          (target address for CONNECT)       │
+│    - ProxyScheme string          (NEW: "http" or "https")           │
+│                                                                     │
+│  Attached to resolver.Address via attributes mechanism              │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               │  opts.ProxyScheme
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  Layer 3: Transport / Connection                                    │
+│  File: internal/transport/proxy.go                                  │
+│  File: internal/transport/http2_client.go                           │
+│                                                                     │
+│  dial() in http2_client.go:                                         │
+│    if proxyattributes present → proxyDial()                         │
+│    else → normal TCP dial                                           │
+│                                                                     │
+│  proxyDial():                                                       │
+│    if opts.ProxyScheme == "https" → tls.Dial() to proxy             │
+│    else → net.Dialer (plaintext TCP) to proxy                       │
+│    then → doHTTPConnectHandshake()                                  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### The critical gap (before this patch)
+
+In `delegatingresolver.go`, the `updateClientConnStateLocked()` method
+constructs `proxyattributes.Options` at two locations (lines 248-251 and
+267-270). In the original code, only `User` and `ConnectAddr` are populated —
+the `proxyURL.Scheme` is available on `r.proxyURL` but is **not** passed
+through the Options struct. This means by the time `proxyDial()` runs, it has
+no way to know whether the proxy expects a TLS or plaintext connection.
+
+### Data flow comparison
+
+**Before (broken for HTTPS proxy):**
+```
+HTTPS_PROXY=https://proxy:443
+  → http.ProxyFromEnvironment() → url.URL{Scheme:"https"}     ✓
+  → delegatingResolver.proxyURL stores full URL                ✓
+  → proxyattributes.Options{User, ConnectAddr}                 ✗ Scheme LOST
+  → proxyDial() → net.Dialer (plaintext TCP)                   ✗ Wrong!
+  → HTTP CONNECT handshake fails (proxy expects TLS)           ✗
+```
+
+**After (working):**
+```
+HTTPS_PROXY=https://proxy:443
+  → http.ProxyFromEnvironment() → url.URL{Scheme:"https"}     ✓
+  → delegatingResolver.proxyURL stores full URL                ✓
+  → proxyattributes.Options{User, ConnectAddr, ProxyScheme}    ✓ Scheme preserved
+  → proxyDial() → DialContext (TCP+keepalive) → tls.Client     ✓
+  → HandshakeContext (context-aware TLS handshake)              ✓
+  → HTTP CONNECT handshake over TLS tunnel                     ✓
+  → gRPC TLS handshake to target through tunnel                ✓
+```
+
+---
+
+## Changes Made
+
+### 1. `internal/proxyattributes/proxyattributes.go`
+
+Added `ProxyScheme string` field to the `Options` struct.
+
+```go
+type Options struct {
+    User        *url.Userinfo
+    ConnectAddr string
+    ProxyScheme string  // NEW: "http" or "https"
+}
+```
+
+### 2. `internal/resolver/delegatingresolver/delegatingresolver.go`
+
+Two call sites in `updateClientConnStateLocked()` now pass the proxy URL
+scheme:
+
+```go
+// Line ~248 (Addresses path)
+proxyattributes.Set(proxyAddr, proxyattributes.Options{
+    User:        r.proxyURL.User,
+    ConnectAddr: targetAddr.Addr,
+    ProxyScheme: r.proxyURL.Scheme,  // NEW
+})
+
+// Line ~267 (Endpoints path)
+proxyattributes.Set(proxyAddr, proxyattributes.Options{
+    User:        r.proxyURL.User,
+    ConnectAddr: targetAddr.Addr,
+    ProxyScheme: r.proxyURL.Scheme,  // NEW
+})
+```
+
+### 3. `internal/transport/proxy.go`
+
+Modified `proxyDial()` to branch on `opts.ProxyScheme`:
+
+- **Both paths** now use `internal.NetDialerWithTCPKeepalive().DialContext(ctx, ...)`
+  for the initial TCP connection, ensuring context-awareness (deadline/cancellation)
+  and TCP keepalive support.
+- **`"https"`**: After TCP dial, wraps the connection with `tls.Client()` and
+  performs `HandshakeContext(ctx)` for a context-aware TLS handshake. The CA
+  certificate for proxy TLS verification is determined in this order:
+  1. Custom CA from the `ROOT_CA_CERT` environment variable
+  2. System certificate pool (Go's default when `RootCAs` is nil)
+- **Other (default)**: Uses the existing plaintext TCP connection, preserving
+  backward compatibility.
+
+Added helper functions:
+- `proxyTLSConfig()` — determines the appropriate TLS configuration
+- `loadProxyCACertPool()` — loads custom CA from `ROOT_CA_CERT` env var
+
+---
+
+## Connection Scenarios
+
+| Environment Variable | Behavior |
+|---------------------|----------|
+| `HTTPS_PROXY=http://proxy:3128` | Plaintext TCP to proxy → HTTP CONNECT → works (unchanged) |
+| `HTTPS_PROXY=https://proxy:443` (no `ROOT_CA_CERT`) | TLS to proxy (system CAs or InsecureSkipVerify fallback) → HTTP CONNECT → works |
+| `HTTPS_PROXY=https://proxy:443` + `ROOT_CA_CERT=/path/to/ca.crt` | TLS to proxy (custom CA verified) → HTTP CONNECT → works |
+| No `HTTPS_PROXY` set | Direct connection, no proxy → works (unchanged) |
+
+---
+
+## Testing
+
+To verify HTTPS proxy support with a local test setup:
+
+```bash
+# 1. Start an HTTPS proxy (e.g., Squid with TLS)
+# 2. Set environment variables
+export HTTPS_PROXY=https://proxy-host:8443
+export ROOT_CA_CERT=/path/to/proxy-ca.crt  # optional if proxy uses publicly-trusted CA
+
+# 3. Run gRPC client — it should connect through the HTTPS proxy
+```
+
+---
+
+## Upstream References
+
+- [grpc/grpc#35372](https://github.com/grpc/grpc/issues/35372) — Feature
+  request for HTTPS proxy support (P2, help wanted)
+- [grpc-go Documentation/proxy.md](https://github.com/grpc/grpc-go/blob/master/Documentation/proxy.md) —
+  Official proxy documentation confirming the limitation
+- [kubernetes-sigs/apiserver-network-proxy#127](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/127) —
+  ANP issue for egress proxy support (frozen)
+- [stolostron/grpc-go PR #5](https://github.com/stolostron/grpc-go/pull/5) —
+  Previous patch for grpc-go v1.51.0
+- [open-cluster-management-io/cluster-proxy PR #172](https://github.com/open-cluster-management-io/cluster-proxy/pull/172) —
+  cluster-proxy proxy environment variable support

--- a/vendor/google.golang.org/grpc/internal/proxyattributes/proxyattributes.go
+++ b/vendor/google.golang.org/grpc/internal/proxyattributes/proxyattributes.go
@@ -35,6 +35,10 @@ const proxyOptionsKey = keyType("grpc.resolver.delegatingresolver.proxyOptions")
 type Options struct {
 	User        *url.Userinfo
 	ConnectAddr string
+	// ProxyScheme is the URL scheme of the proxy, e.g. "http" or "https".
+	// When set to "https", the transport will establish a TLS connection
+	// to the proxy server before performing the HTTP CONNECT handshake.
+	ProxyScheme string
 }
 
 // Set returns a copy of addr with opts set in its attributes.

--- a/vendor/google.golang.org/grpc/internal/resolver/delegatingresolver/delegatingresolver.go
+++ b/vendor/google.golang.org/grpc/internal/resolver/delegatingresolver/delegatingresolver.go
@@ -22,6 +22,7 @@ package delegatingresolver
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -236,7 +237,19 @@ func (r *delegatingResolver) updateClientConnStateLocked() error {
 	if len(r.proxyAddrs) == 1 {
 		proxyAddr = r.proxyAddrs[0]
 	} else {
-		proxyAddr = resolver.Address{Addr: r.proxyURL.Host}
+		proxyHost := r.proxyURL.Host
+		// When the proxy URL omits the port (e.g. "https://proxy-host"),
+		// url.URL.Host contains only the hostname without a port. Add the
+		// default port based on the scheme so that net.Dial does not fail
+		// with "missing port in address".
+		if _, _, err := net.SplitHostPort(proxyHost); err != nil {
+			defaultPort := "80"
+			if r.proxyURL.Scheme == "https" {
+				defaultPort = "443"
+			}
+			proxyHost = net.JoinHostPort(proxyHost, defaultPort)
+		}
+		proxyAddr = resolver.Address{Addr: proxyHost}
 	}
 	var addresses []resolver.Address
 	for _, targetAddr := range (*r.targetResolverState).Addresses {

--- a/vendor/google.golang.org/grpc/internal/resolver/delegatingresolver/delegatingresolver.go
+++ b/vendor/google.golang.org/grpc/internal/resolver/delegatingresolver/delegatingresolver.go
@@ -248,6 +248,7 @@ func (r *delegatingResolver) updateClientConnStateLocked() error {
 		addresses = append(addresses, proxyattributes.Set(proxyAddr, proxyattributes.Options{
 			User:        r.proxyURL.User,
 			ConnectAddr: targetAddr.Addr,
+			ProxyScheme: r.proxyURL.Scheme,
 		}))
 	}
 
@@ -267,6 +268,7 @@ func (r *delegatingResolver) updateClientConnStateLocked() error {
 				addrs = append(addrs, proxyattributes.Set(proxyAddr, proxyattributes.Options{
 					User:        r.proxyURL.User,
 					ConnectAddr: targetAddr.Addr,
+					ProxyScheme: r.proxyURL.Scheme,
 				}))
 			}
 		}

--- a/vendor/google.golang.org/grpc/internal/transport/proxy.go
+++ b/vendor/google.golang.org/grpc/internal/transport/proxy.go
@@ -21,6 +21,8 @@ package transport
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -28,6 +30,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/proxyattributes"
@@ -35,6 +39,11 @@ import (
 )
 
 const proxyAuthHeaderKey = "Proxy-Authorization"
+
+// proxyCAEnvVar is an environment variable to specify the CA certificate file
+// for verifying TLS connections to HTTPS proxy servers. If not set, the system
+// certificate pool is used.
+const proxyCAEnvVar = "ROOT_CA_CERT"
 
 // To read a response from a net.Conn, http.ReadResponse() takes a bufio.Reader.
 // It's possible that this reader reads more than what's need for the response
@@ -98,13 +107,52 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, grpcUA string, o
 	return conn, nil
 }
 
-// proxyDial establishes a TCP connection to the specified address and performs an HTTP CONNECT handshake.
+// proxyDial establishes a TCP connection to the specified address and performs
+// an HTTP CONNECT handshake. When the proxy scheme is "https", a TLS
+// connection is established to the proxy server first. The CA certificate for
+// verifying the proxy's TLS certificate can be specified via the
+// ROOT_CA_CERT environment variable; if not set, the system certificate
+// pool is used.
 func proxyDial(ctx context.Context, addr resolver.Address, grpcUA string, opts proxyattributes.Options) (net.Conn, error) {
 	conn, err := internal.NetDialerWithTCPKeepalive().DialContext(ctx, "tcp", addr.Addr)
 	if err != nil {
 		return nil, err
 	}
+
+	if opts.ProxyScheme == "https" {
+		tlsConf, err := proxyTLSConfig(addr.Addr)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+		tlsConn := tls.Client(conn, tlsConf)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("TLS handshake to proxy %s failed: %v", addr.Addr, err)
+		}
+		conn = tlsConn
+	}
+
 	return doHTTPConnectHandshake(ctx, conn, grpcUA, opts)
+}
+
+// proxyTLSConfig returns a TLS config for connecting to an HTTPS proxy at the
+// given address. If ROOT_CA_CERT is set, its CA is used for
+// verification. Otherwise, the system certificate pool is used (Go's default
+// behavior when RootCAs is nil).
+func proxyTLSConfig(proxyAddr string) (*tls.Config, error) {
+	// Extract the hostname from the proxy address for SNI/verification.
+	host, _, err := net.SplitHostPort(proxyAddr)
+	if err != nil {
+		host = proxyAddr
+	}
+
+	caCertPool, err := loadProxyCACertPool()
+	if err != nil {
+		return nil, err
+	}
+	// When caCertPool is nil, Go uses the system certificate pool by default.
+	return &tls.Config{ServerName: host, RootCAs: caCertPool}, nil
 }
 
 func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) error {
@@ -113,4 +161,23 @@ func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) erro
 		return fmt.Errorf("failed to write the HTTP request: %v", err)
 	}
 	return nil
+}
+
+// loadProxyCACertPool loads the CA certificate specified by the ROOT_CA_CERT
+// environment variable into a certificate pool. Returns (nil, nil) when the
+// environment variable is not set.
+func loadProxyCACertPool() (*x509.CertPool, error) {
+	caFile := os.Getenv(proxyCAEnvVar)
+	if caFile == "" {
+		return nil, nil
+	}
+	certPool := x509.NewCertPool()
+	caCert, err := os.ReadFile(filepath.Clean(caFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read proxy CA cert %s: %v", caFile, err)
+	}
+	if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+		return nil, fmt.Errorf("failed to append proxy CA cert to the cert pool")
+	}
+	return certPool, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -207,7 +207,7 @@ golang.org/x/time/rate
 # google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb
 ## explicit; go 1.23.0
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.72.1
+# google.golang.org/grpc v1.72.1 => github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2
 ## explicit; go 1.23
 google.golang.org/grpc
 google.golang.org/grpc/attributes
@@ -746,4 +746,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
+# google.golang.org/grpc => github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client => ./konnectivity-client

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -207,7 +207,7 @@ golang.org/x/time/rate
 # google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb
 ## explicit; go 1.23.0
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.72.1 => github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2
+# google.golang.org/grpc v1.72.1 => github.com/stolostron/grpc-go v0.0.0-20260313103756-441825381483
 ## explicit; go 1.23
 google.golang.org/grpc
 google.golang.org/grpc/attributes
@@ -746,5 +746,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# google.golang.org/grpc => github.com/stolostron/grpc-go v0.0.0-20260311160540-c45dcf25edc2
+# google.golang.org/grpc => github.com/stolostron/grpc-go v0.0.0-20260313103756-441825381483
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client => ./konnectivity-client


### PR DESCRIPTION
## Summary
- Replace `google.golang.org/grpc v1.72.1` with `github.com/stolostron/grpc-go` (v1.72.1-patch branch) via go.mod replace directive
- This picks up the HTTPS proxy support patch needed for ANP (apiserver-network-proxy)
- Updated vendor directory to reflect the patched gRPC dependency

## Changes
- `go.mod`: Added replace directive for `google.golang.org/grpc`
- `go.sum`: Updated checksums
- `vendor/`: Updated vendored gRPC files with HTTPS proxy patch

## Test plan
- [ ] Verify `go build ./...` succeeds
- [ ] Verify gRPC connections work through HTTPS proxy
- [ ] Run existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)